### PR TITLE
Fix release workflow secrets guard; bump version to 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    # The secrets context is not allowed in step `if:` expressions (the whole
+    # workflow fails to parse); hoist the presence check into an env var.
+    env:
+      HAS_SIGNING_KEY: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -39,13 +44,13 @@ jobs:
       # secret is configured. Without it, a release still produces the GitHub
       # Release and attached jars above.
       - name: Set up GPG
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: env.HAS_SIGNING_KEY == 'true'
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --import-ownertrust
 
       - name: Deploy to Maven Central
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: env.HAS_SIGNING_KEY == 'true'
         run: mvn deploy -P build-cli-jar -DskipTests --settings .github/maven-settings.xml
 
       - name: Update version in pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>oashield</artifactId>
     <packaging>jar</packaging>
     <name>oashield</name>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Summary
- The `secrets` context is not allowed in step-level `if:` expressions; the guards added in 7b30a2a made GitHub reject `release.yml` at plan time, so the `v0.2.0` tag push produced a 0-second workflow-file failure — no jar upload and no version bump.
- Hoists the GPG-secret presence check into a job-level `env` var (`HAS_SIGNING_KEY`), where reading secrets is allowed, and guards the two publish steps on it.
- Bumps `pom.xml` to 0.2.0 — the commit the workflow would have pushed had it run (the tag event has already fired).

The v0.2.0 release itself is already complete: notes published and both jars (built from this branch at version 0.2.0, CLI smoke-tested) uploaded manually. This PR just makes the next tagged release work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)